### PR TITLE
Improve linear ticks

### DIFF
--- a/app/assets/javascripts/extensions/view.js
+++ b/app/assets/javascripts/extensions/view.js
@@ -30,8 +30,8 @@ function (Backbone) {
        * @return {Function}
        */
       numberListFormatter: function (values) {
-        function isAnExactMultipleOf(value) {
-          return function(n) { return n % value === 0; };
+        function isAnExactMultipleOf(magnitude) {
+          return function(n) { return n % magnitude === 0; };
         }
 
         var max = values.reduce(function(a,b) {return a > b ? a : b});

--- a/app/assets/javascripts/extensions/view.js
+++ b/app/assets/javascripts/extensions/view.js
@@ -43,6 +43,41 @@ function (Backbone) {
           if (value === 0) return "0";
           return format(value, magnitude, decimalPlaces);
         };
+      },
+
+      /**
+       * Returns an object describing evenly spaced, nice tick values given an extent and a minimum tick count.
+       * The returned object will include the values, extent and step of the ticks.
+       * The extent may be extended to include the next nice tick value.
+       *
+       * @param extent
+       * @param minimumTickCount
+       * @return {Object}
+       */
+      calculateLinearTicks: function(extent, minimumTickCount) {
+        if (extent[0] >= extent[1]) {
+          throw new Error("Upper bound must be larger than lower.");
+        }
+        var targetTickCount = minimumTickCount - 1,
+            span = extent[1] - extent[0],
+            step = Math.pow(10, Math.floor(Math.log(span / targetTickCount) / Math.LN10)),
+            err = targetTickCount / span * step;
+
+        // Filter ticks to get closer to the desired count.
+        if (err <= .15) step *= 10;
+        else if (err <= .35) step *= 5;
+        else if (err <= .75) step *= 2;
+
+        // Round start and stop values to step interval.
+        var first = Math.floor(extent[0] / step) * step,
+            last = Math.ceil(extent[1] / step) * step,
+            lastInclusive = last + step / 2;
+
+        return {
+          values:d3.range.apply(d3, [first, lastInclusive, step]),
+          extent:[first, last],
+          step:step
+        };
       }
     });
     

--- a/app/assets/javascripts/licensing/views/totalapplications.js
+++ b/app/assets/javascripts/licensing/views/totalapplications.js
@@ -50,7 +50,7 @@ function (Graph, Axis, Line) {
             return this.scales.y;
           },
           tickFormat: function () {
-            return this.numberListFormatter([this.scales.y.domain()[1]]);
+            return this.numberListFormatter(this.scales.y.tickValues);
           }
         }
       },
@@ -86,9 +86,12 @@ function (Graph, Axis, Line) {
       var yScale = this.d3.scale.linear();
       var max = this.d3.max(collection.models, function (model) {
         return model.get('_count');
-      })
-      yScale.domain([0, max]).nice();
-      yScale.range([this.innerHeight, 0]);
+      });
+      var tickValues = this.calculateLinearTicks([0, max], 7);
+      yScale.domain(tickValues.extent);
+      yScale.rangeRound([this.innerHeight, 0]);
+      yScale.tickValues = tickValues.values;
+
       return yScale;
     }
   });

--- a/spec/javascripts/spec/extensions/spec.view.js
+++ b/spec/javascripts/spec/extensions/spec.view.js
@@ -9,7 +9,7 @@ function (View, Backbone) {
       expect(view instanceof Backbone.View).toBe(true);
     });
 
-    describe ("numberListFormatter", function() {
+    describe("numberListFormatter", function() {
       describe("when all label are lower than 1000", function() {
         it("should format all labels as units", function() {
           var formatter = View.prototype.numberListFormatter([0, 50, 100, 150]);
@@ -29,7 +29,7 @@ function (View, Backbone) {
           expect(formatter(1000)).toBe("1.0k");
           expect(formatter(1500)).toBe("1.5k");
         });
-      })
+      });
 
       describe("when labels go over 1,000,000", function() {
         it("should format all labels as million", function() {
@@ -57,5 +57,81 @@ function (View, Backbone) {
 
     });
 
+    describe("calculateLinearTicks", function() {
+      describe("extending the extent", function() {
+        it("should extend the top limit beyond the max", function() {
+          var ticks = View.prototype.calculateLinearTicks([0, 7000], 5);
+          expect(ticks.values).toEqual([0, 2000, 4000, 6000, 8000]);
+          expect(ticks.extent).toEqual([0, 8000]);
+          expect(ticks.step).toEqual(2000);
+        });
+
+        it("should extend the bottom limit beyond the minimum", function() {
+          var ticks = View.prototype.calculateLinearTicks([10, 8000], 5);
+          expect(ticks.values).toEqual([0, 2000, 4000, 6000, 8000]);
+          expect(ticks.extent).toEqual([0, 8000]);
+          expect(ticks.step).toEqual(2000);
+        });
+      });
+
+      describe("number of ticks", function() {
+        var extent = [0, 61241];
+        it("should increase the number of ticks if it allows nicer ticks", function() {
+          var ticks = View.prototype.calculateLinearTicks(extent, 2);
+          expect(ticks.values).toEqual([0, 50000, 100000]);
+        });
+        it("should not change the number of ticks if it does not need to", function() {
+          var ticks = View.prototype.calculateLinearTicks(extent, 3);
+          expect(ticks.values).toEqual([0, 50000, 100000]);
+        });
+        it("should decrease the number of ticks if it allows nicer ticks", function() {
+          var extent = [0, 4000];
+          var ticks = View.prototype.calculateLinearTicks(extent, 7);
+          expect(ticks.values).toEqual([0, 1000, 2000, 3000, 4000])
+        });
+      });
+
+      // Because this function is designed to work with various and overlapping
+      describe("various ranges", function() {
+        it("should return valid ticks for 0-5 with 20 ticks", function() {
+          var ticks = View.prototype.calculateLinearTicks([0, 5], 20);
+          expect(ticks.values).toEqual([0, 0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4, 1.6, 1.8, 2, 2.2, 2.4, 2.6, 2.8, 3, 3.2, 3.4, 3.6, 3.8, 4, 4.2, 4.4, 4.6, 4.8, 5]);
+          expect(ticks.extent).toEqual([0, 5]);
+          expect(ticks.step).toEqual(0.2);
+        });
+
+        it("should return valid ticks for 0-1000 with 10 ticks", function() {
+          var ticks = View.prototype.calculateLinearTicks([0, 1000], 10);
+          expect(ticks.values).toEqual([0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]);
+          expect(ticks.extent).toEqual([0, 1000]);
+          expect(ticks.step).toEqual(100);
+        });
+
+        it("should return valid ticks for 0-8000 with 9 ticks", function() {
+          var ticks = View.prototype.calculateLinearTicks([0, 5000], 7);
+          expect(ticks.values).toEqual([0, 1000, 2000, 3000, 4000, 5000]);
+          expect(ticks.extent).toEqual([0, 5000]);
+          expect(ticks.step).toEqual(1000);
+        });
+
+        it("should return valid ticks for 900k-1m with 5 ticks", function() {
+          var ticks = View.prototype.calculateLinearTicks([9.5e5, 1e6], 5);
+          expect(ticks.values).toEqual([950000, 960000, 970000, 980000, 990000, 1000000]);
+          expect(ticks.extent).toEqual([950000, 1000000]);
+          expect(ticks.step).toEqual(10000);
+        });
+      });
+
+      describe("invalid argument handling", function() {
+        it("should raise an exception if lower bound is > upper bound", function() {
+          expect(function() { View.prototype.calculateLinearTicks([0, -1], 5)})
+              .toThrow(new Error("Upper bound must be larger than lower."));
+        });
+        it("should raise an exception if lower bound is == upper bound", function() {
+          expect(function() { View.prototype.calculateLinearTicks([0, 0], 5)})
+              .toThrow(new Error("Upper bound must be larger than lower."));
+        });
+      })
+    });
   });
 });

--- a/spec/javascripts/spec/licensing/views/spec.totalapplications.js
+++ b/spec/javascripts/spec/licensing/views/spec.totalapplications.js
@@ -18,12 +18,12 @@ function (Graph, Collection, moment) {
         {
           _start_at: moment('2013-01-21').startOf('day'),
           _end_at: moment('2013-01-28').startOf('day'),
-          _count: 124
+          _count: 569
         },
         {
           _start_at: moment('2013-01-28').startOf('day'),
           _end_at: moment('2013-02-04').startOf('day'),
-          _count: 41
+          _count: 1024
         }
       ]);
       spyOn(Graph.prototype, "prepareGraphArea");
@@ -48,14 +48,19 @@ function (Graph, Collection, moment) {
     
     describe("calcYScale", function() {
       it("scales domain from 0 to nice value above max value", function() {
-        expect(graph.calcYScale().domain()).toEqual([0, 130]);
+        expect(graph.calcYScale().domain()).toEqual([0, 1200]);
       });
       
       it("scales range to inner height", function() {
         expect(graph.calcYScale().range()).toEqual([333, 0]);
       });
+
+      it("sets the tickValues correctly", function() {
+        expect(graph.calcYScale().tickValues)
+            .toEqual([0, 200, 400, 600, 800, 1000, 1200])
+      })
     });
-    
+
   });
   
 });


### PR DESCRIPTION
Base the tick formatter off the entire set of ticks rather than just the extent. This avoids a couple of formatting bugs when the max value if close to a magnitude boundary.

**Before**
`200, 400, 600, 800, 1000`
formatted as
`0k, 0k, 1k, 1k, 1k`

**After**
`200, 400, 600, 800, 1000`
formatted as
`0.2k, 0.4k, 0.6k, 0.8k, 1.0k`
