### PR TITLE
ensure that fake API is fully loaded before application

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,34 @@
+/**
+ * Loads fake API when required.
+ * Bootstraps application only when not running tests.
+ */
+
+define({
+  load: function(name, req, onLoad, config) {
+    
+    var that = this;
+    var loadApplication = function () {
+      if (window.jasmine) {
+        // Don't initialise app when running unit tests
+        onLoad.call(that);
+      } else {
+        // Load controller for this page
+        var controller = $('#wrapper').data('controller');
+        req([controller], function (controller) {
+          onLoad.call(that);
+        });
+      }
+    }
+
+    var backdropUrl = $('#wrapper').data('backdrop-url');
+    if (!window.jasmine && backdropUrl && backdropUrl.indexOf('//fakeapi') == -1) {
+      // use real API
+      loadApplication();
+    } else {
+      // use fake API
+      req(['fakeapi'], function (fakeapi) {
+        loadApplication();
+      });
+    }
+  }
+});

--- a/app/assets/javascripts/bootstrap.js
+++ b/app/assets/javascripts/bootstrap.js
@@ -1,0 +1,8 @@
+define([
+  'require',
+  'application!'
+],
+function () {
+  // Simple proxy to 'application' module. require.js does not like plugins
+  // as config dependencies.
+});

--- a/app/assets/javascripts/config.js
+++ b/app/assets/javascripts/config.js
@@ -2,9 +2,7 @@
 require.config({
 
   deps: [
-    'fakeapi',
-    // get controller path for this page from wrapper element
-    window.$ && $('#wrapper').data('controller')
+    'bootstrap'
   ],
 
   paths: {

--- a/spec/javascripts/fakeapi.js
+++ b/spec/javascripts/fakeapi.js
@@ -4,13 +4,6 @@ define([
   'fakeapi/licensing/applications'
 ],
 function () {
-  
-  var backdropUrl = $('#wrapper').data('backdrop-url');
-  if (!window.jasmine && backdropUrl && backdropUrl.indexOf('//fakeapi') == -1) {
-    // use real API
-    return;
-  }
-  
   // use XMLHttpRequest for cross domain mock calls on IE
   // as mockjax does not replace XDomainRequest
   $.ajaxPrefilter( function( options, originalOptions, jqXHR ) {


### PR DESCRIPTION
Sometimes, graphs wouldn't load when using fake API. I believe that this was due to a race condition in loading the fake API and the application. I've changed the bootstrap process to ensure that the fake API is fully loaded before the application controller is loaded. I've also moved the API switcher logic out of the fake API.
