### PR TITLE
Correct the backdrop url and path

### DIFF
--- a/app/assets/javascripts/extensions/collection.js
+++ b/app/assets/javascripts/extensions/collection.js
@@ -50,7 +50,7 @@ function ($, Backbone, Model, moment) {
         }
       });
 
-      return this.baseUrl + this.queryUrl + '/?' + $.param(params);
+      return this.baseUrl + 'performance/' + this.queryUrl + '/api?' + $.param(params);
     }
   });
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,10 @@ class ApplicationController < ActionController::Base
   slimmer_template :homepage
 
   def backdrop_api
-    Rails.configuration.use_api_stub ? BackdropAPIStub.new : BackdropAPI.new(Rails.configuration.backdrop_url)
+    Rails.configuration.use_api_stub ? BackdropAPIStub.new : BackdropAPI.new(backdrop_url)
+  end
+
+  def backdrop_url
+    Rails.application.config.backdrop_url
   end
 end

--- a/app/models/backdrop_api.rb
+++ b/app/models/backdrop_api.rb
@@ -11,13 +11,13 @@ class BackdropAPI
   
   def get_licences
     transport = Songkick::Transport::HttParty.new(@backdrop_url, :user_agent => "Limelight", :timeout => 30)
-    response = transport.get("/licensing?group_by=licenceUrlSlug&collect=licenceName&period=all")
+    response = transport.get("/performance/licensing/api?group_by=licenceUrlSlug&collect=licenceName&period=week")
     response.data
   end
   
   def get_licence(slug)
     transport = Songkick::Transport::HttParty.new(@backdrop_url, :user_agent => "Limelight", :timeout => 30)
-    response = transport.get("/licensing?filter_by=licenceUrlSlug:#{slug}&group_by=licenceUrlSlug&collect=licenceName&period=all")
+    response = transport.get("/performance/licensing/api?filter_by=licenceUrlSlug:#{slug}&group_by=licenceUrlSlug&collect=licenceName&period=all")
     response.data
   end
   

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,8 +58,6 @@ module Limelight
 
     config.assets.prefix = 'limelight'
 
-    config.backdrop_url = Plek.new.find("read.backdrop")
-
     # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
     config.assets.precompile += %w( *.css *.js )
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,5 @@ Limelight::Application.configure do
 
   config.assets.paths << Rails.root.join("spec", "javascripts")
   
-  config.backdrop_url = ENV["BACKDROP_URL"] if ENV.has_key?("BACKDROP_URL")
-
   config.use_api_stub = ENV.has_key?("USE_API_STUB")
 end

--- a/config/initializers/backdrop.rb
+++ b/config/initializers/backdrop.rb
@@ -1,0 +1,1 @@
+Limelight::Application.config.backdrop_url = ENV["BACKDROP_URL"] || 'http://publicapi.dev.gov.uk'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,14 +1,15 @@
 require "spec_helper"
 
 describe ApplicationController do
-  controller do
-    def index
-      @my_action_data = backdrop_api.my_action_data
-      render :nothing => true
-    end
-  end
 
   describe "use_api_stub" do
+    controller do
+      def index
+        @my_action_data = backdrop_api.my_action_data
+        render :nothing => true
+      end
+    end
+
     it "should use the api stub when use_api_stub is true" do
       Rails.configuration.use_api_stub = true
       BackdropAPI.should_not_receive(:new)
@@ -31,6 +32,28 @@ describe ApplicationController do
       assert_response :ok
 
       assigns(:my_action_data).should == {"bar" => "foo"}
+    end
+  end
+
+  describe "backdrop_url" do
+    controller do
+      def index
+        @backdrop_url = backdrop_url
+        render :nothing => true
+      end
+    end
+
+    before(:each) do
+      Rails.configuration.backdrop_url = nil
+    end
+
+    it "should use backdrop_url if configured" do
+      Rails.configuration.backdrop_url = 'http://my.backdrop/path'
+
+      get :index
+
+      assert_response :ok
+      assigns(:backdrop_url).should == "http://my.backdrop/path"
     end
   end
 end

--- a/spec/javascripts/fakeapi/licensing/applications.js
+++ b/spec/javascripts/fakeapi/licensing/applications.js
@@ -11,7 +11,7 @@ function (require, Timeseries, Random) {
       this.rnd = new Random(1);
     },
     
-    url: /\/licensing\/?\?(.*)/,
+    url: /\/licensing\/?.*\?(.*)/,
     
     getValue: function (start, end) {
       return {

--- a/spec/javascripts/fakeapi/licensing/perlicence.js
+++ b/spec/javascripts/fakeapi/licensing/perlicence.js
@@ -11,7 +11,7 @@ function (require, Timeseries, Random) {
       this.rnd = new Random(1);
     },
     
-    url: /\/licensing\/?\?(.*group_by=authorityUrlSlug.*)/,
+    url: /\/licensing\/?.*\?(.*group_by=authorityUrlSlug.*)/,
     
     getValue: function (start, end, query) {
       

--- a/spec/javascripts/spec/extensions/spec.collection.js
+++ b/spec/javascripts/spec/extensions/spec.collection.js
@@ -63,7 +63,7 @@ function (Collection, Model, Backbone) {
           
           it("constructs a backdrop query URL without params", function() {
             var collection = new TestCollection();
-            expect(collection.url()).toEqual('//testdomain/bucketname/?');
+            expect(collection.url()).toEqual('//testdomain/performance/bucketname/api?');
           });
           
           it("constructs a backdrop query URL with static params", function() {
@@ -72,7 +72,7 @@ function (Collection, Model, Backbone) {
               a: 1,
               b: 'foo bar'
             }
-            expect(collection.url()).toEqual('//testdomain/bucketname/?a=1&b=foo+bar');
+            expect(collection.url()).toEqual('//testdomain/performance/bucketname/api?a=1&b=foo+bar');
           });
           
           it("constructs a backdrop query URL with dynamic params", function() {
@@ -84,7 +84,7 @@ function (Collection, Model, Backbone) {
                 b: this.testProp
               };
             };
-            expect(collection.url()).toEqual('//testdomain/bucketname/?a=1&b=foo+bar');
+            expect(collection.url()).toEqual('//testdomain/performance/bucketname/api?a=1&b=foo+bar');
           });
           
           it("constructs a backdrop query URL with moment date params", function() {
@@ -96,7 +96,7 @@ function (Collection, Model, Backbone) {
                 somedate: this.moment('03/08/2013 14:53:26 +00:00', 'MM/DD/YYYY HH:mm:ss T')
               };
             };
-            expect(collection.url()).toEqual('//testdomain/bucketname/?a=1&somedate=2013-03-08T14%3A53%3A26%2B00%3A00');
+            expect(collection.url()).toEqual('//testdomain/performance/bucketname/api?a=1&somedate=2013-03-08T14%3A53%3A26%2B00%3A00');
           });
         });
     });

--- a/spec/unit/backdrop_api_spec.rb
+++ b/spec/unit/backdrop_api_spec.rb
@@ -31,7 +31,7 @@ describe BackdropAPI do
       response_stub = double("response")
       
       httparty_stub.should_receive(:get)
-        .with("/licensing?group_by=licenceUrlSlug&collect=licenceName&period=all")
+        .with("/performance/licensing/api?group_by=licenceUrlSlug&collect=licenceName&period=week")
         .and_return(response_stub)
       
       response_stub.stub(:data).and_return(response)
@@ -76,7 +76,7 @@ describe BackdropAPI do
       response_stub = double("response")
       
       httparty_stub.should_receive(:get)
-        .with("/licensing?filter_by=licenceUrlSlug:application-to-licence-a-street-collection&group_by=licenceUrlSlug&collect=licenceName&period=all")
+        .with("/performance/licensing/api?filter_by=licenceUrlSlug:application-to-licence-a-street-collection&group_by=licenceUrlSlug&collect=licenceName&period=all")
         .and_return(response_stub)
       
       response_stub.stub(:data).and_return(response)


### PR DESCRIPTION
This makes the backdrop base url and path work across development,
preview and production.
- Configure backdrop base url in an initializer so that it can be easily
  change between organisations.
- Update request path to match where the api is being served from. This
  needs improvement. Ideally configuring a pattern in one place and then
  using it everywhere.
