### PR TITLE
Don't double escape what safesync already escaped

### DIFF
--- a/app/assets/javascripts/extensions/views/filter.js
+++ b/app/assets/javascripts/extensions/views/filter.js
@@ -64,7 +64,7 @@ function (View) {
       View.prototype.render.apply(this, arguments);
       
       if (this.label) {
-        var label = $('<label/>').prop('for', this.id).text(this.label);
+        var label = $('<label/>').prop('for', this.id).html(this.label);
         this.$el.append(label);
       }
       

--- a/app/assets/javascripts/extensions/views/graph/linelabel.js
+++ b/app/assets/javascripts/extensions/views/graph/linelabel.js
@@ -113,7 +113,7 @@ function (Component) {
       selection.each(function (model, i) {
         var selection = d3.select(this)
         selection.selectAll("text")
-            .text(model.get('title'))
+            .text(_.unescape(model.get('title')))
             .attr('transform', 'translate(' + xOffset + ', 6)');
       });
     },

--- a/app/assets/javascripts/licensing/views/applicationstable.js
+++ b/app/assets/javascripts/licensing/views/applicationstable.js
@@ -15,7 +15,7 @@ function (Table) {
         },
         sortable: true,
         getValue: function (model) {
-          return $('<a>').text(model.get('name')).prop('href', model.get('url'));
+          return $('<a>').html(model.get('name')).prop('href', model.get('url'));
         }
       },
       {


### PR DESCRIPTION
We use global escaping of JSON received from backdrop. Because of that
we should not escape things in jQuery and d3.
- in jQuery that requires using html method instead of text method.
- in d3 we cannot use html method because it operates on innerHTML
  and this attribute is missing in SVG. Instead we unescape previously
  escaped text, and rely on d3 escaping it.

That sounds bizarre but it is more safe to escape by default, than to
expose potential XSS vulnerability.
