### PR TITLE
2.0.0 failures should not block pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+matrix:
+  allow_failures:
+    - rvm: 2.0.0


### PR DESCRIPTION
We allow failures in that environment for now, since we have no plans
to deploy to a Ruby 2.0.x environment.
