### PR TITLE
Change backdrop URLs to support sections in a service

### DIFF
--- a/app/assets/javascripts/extensions/collections/collection.js
+++ b/app/assets/javascripts/extensions/collections/collection.js
@@ -77,7 +77,7 @@ function (Backbone, Model, SafeSync, moment) {
         }
       });
 
-      return this.baseUrl + 'performance/' + this.queryUrl + '/api?' + $.param(params, true);
+      return this.baseUrl + 'performance/' + this.serviceName + '/api/' + this.apiName +'?' + $.param(params, true);
     },
     
     /**

--- a/app/assets/javascripts/licensing/collections/all-entities.js
+++ b/app/assets/javascripts/licensing/collections/all-entities.js
@@ -28,7 +28,8 @@ function (require, Collection, Authority, Licence) {
       return response.data;
     },
     
-    queryUrl: 'licensing',
+    serviceName: 'licensing',
+    apiName: 'application',
     
     queryId: 'all-entities',
 

--- a/app/assets/javascripts/licensing/collections/applications-conversion.js
+++ b/app/assets/javascripts/licensing/collections/applications-conversion.js
@@ -3,7 +3,8 @@ define([
 ], function(Collection) {
   var ApplicationsConversionCollection = Collection.extend({
     
-    queryUrl: 'licensing_conversion',
+    serviceName: 'licensing',
+    apiName: 'journey',
 
     queryId: 'applications-conversion',
 

--- a/app/assets/javascripts/licensing/collections/applications-detail-lastweek.js
+++ b/app/assets/javascripts/licensing/collections/applications-detail-lastweek.js
@@ -21,7 +21,8 @@ function (require, Collection) {
       return response.data;
     },
     
-    queryUrl: 'licensing',
+    serviceName: 'licensing',
+    apiName: 'application',
     
     queryId: 'applications-detail-lastweek',
 

--- a/app/assets/javascripts/licensing/collections/applications-total-weekly.js
+++ b/app/assets/javascripts/licensing/collections/applications-total-weekly.js
@@ -7,7 +7,8 @@ function (Collection, Group) {
 
     model: Group,
     
-    queryUrl: 'licensing',
+    serviceName: 'licensing',
+    apiName: 'application',
 
     queryId: 'applications-total-weekly',
     

--- a/app/models/backdrop_api.rb
+++ b/app/models/backdrop_api.rb
@@ -11,23 +11,23 @@ class BackdropAPI
   end
   
   def get_licences
-    response = get("/performance/licensing/api?group_by=licenceUrlSlug&collect=licenceName&sort_by=licenceName:ascending")
+    response = get("#{path("licensing", "application")}?group_by=licenceUrlSlug&collect=licenceName&sort_by=licenceName:ascending")
     response.data
   end
 
   def get_authorities
-    response = get("/performance/licensing/api?group_by=authorityUrlSlug&collect=authorityName&sort_by=authorityName:ascending")
+    response = get("#{path("licensing", "application")}?group_by=authorityUrlSlug&collect=authorityName&sort_by=authorityName:ascending")
     response.data
   end
 
   def get_licence(slug)
-    response = get("/performance/licensing/api?filter_by=licenceUrlSlug:#{slug}&group_by=licenceUrlSlug&collect=licenceName")
+    response = get("#{path("licensing", "application")}?filter_by=licenceUrlSlug:#{slug}&group_by=licenceUrlSlug&collect=licenceName")
     response.data
   end
 
   def get_authority(slug)
     response = get(
-      "/performance/licensing/api?filter_by=authorityUrlSlug:#{slug}" +
+      "#{path("licensing", "application")}?filter_by=authorityUrlSlug:#{slug}" +
       "&group_by=authorityUrlSlug&collect=authorityName"
     )
     response.data
@@ -42,6 +42,10 @@ class BackdropAPI
     end
 
     transport.get(path)
+  end
+
+  def path(service, bucket)
+    "/performance/#{service}/api/#{bucket}"
   end
 
 end

--- a/spec/javascripts/spec/extensions/spec.collection.js
+++ b/spec/javascripts/spec/extensions/spec.collection.js
@@ -56,7 +56,8 @@ function (Collection, Model, Backbone) {
       beforeEach(function() {
         TestCollection = Collection.extend({
           baseUrl: '//testdomain/',
-          queryUrl: 'bucketname',
+          serviceName: 'service',
+          apiName: 'apiname'
           queryId: 'testid'
         });
         spyOn(TestCollection.prototype, "sync");
@@ -75,13 +76,14 @@ function (Collection, Model, Backbone) {
       beforeEach(function() {
         TestCollection = Collection.extend({
           baseUrl: '//testdomain/',
-          queryUrl: 'bucketname'
+          serviceName: 'service',
+          apiName: 'apiname'
         });
       });
 
       it("constructs a backdrop query URL without params", function() {
         var collection = new TestCollection();
-        expect(collection.url()).toEqual('//testdomain/performance/bucketname/api?');
+        expect(collection.url()).toEqual('//testdomain/performance/service/api/apiname?');
       });
 
       it("constructs a backdrop query URL with static params", function() {
@@ -90,7 +92,7 @@ function (Collection, Model, Backbone) {
           a: 1,
           b: 'foo bar'
         }
-        expect(collection.url()).toEqual('//testdomain/performance/bucketname/api?a=1&b=foo+bar');
+        expect(collection.url()).toEqual('//testdomain/performance/service/api/apiname?a=1&b=foo+bar');
       });
 
       it("constructs a backdrop query URL with multiple values for a single parameter", function() {
@@ -98,7 +100,7 @@ function (Collection, Model, Backbone) {
         collection.queryParams = {
           a: [1, 'foo']
         }
-        expect(collection.url()).toEqual('//testdomain/performance/bucketname/api?a=1&a=foo');
+        expect(collection.url()).toEqual('//testdomain/performance/service/api/apiname?a=1&a=foo');
       });
 
       it("constructs a backdrop query URL with dynamic params", function() {
@@ -110,7 +112,7 @@ function (Collection, Model, Backbone) {
             b: this.testProp
           };
         };
-        expect(collection.url()).toEqual('//testdomain/performance/bucketname/api?a=1&b=foo+bar');
+        expect(collection.url()).toEqual('//testdomain/performance/service/api/apiname?a=1&b=foo+bar');
       });
 
       it("constructs a backdrop query URL with moment date params", function() {
@@ -122,7 +124,7 @@ function (Collection, Model, Backbone) {
             somedate: this.moment('03/08/2013 14:53:26 +00:00', 'MM/DD/YYYY HH:mm:ss T')
           };
         };
-        expect(collection.url()).toEqual('//testdomain/performance/bucketname/api?a=1&somedate=2013-03-08T14%3A53%3A26%2B00%3A00');
+        expect(collection.url()).toEqual('//testdomain/performance/service/api/apiname?a=1&somedate=2013-03-08T14%3A53%3A26%2B00%3A00');
       });
 
       it("constructs a backdrop query URL with a single filter parameter", function () {
@@ -137,7 +139,7 @@ function (Collection, Model, Backbone) {
           };
         };
         var url = collection.url()
-        expect(url).toMatch('//testdomain/performance/bucketname/api?');
+        expect(url).toMatch('//testdomain/performance/service/api/apiname?');
         expect(url).toMatch('filter_by=foo%3Abar');
         expect(url).toMatch('a=1');
       });
@@ -155,7 +157,7 @@ function (Collection, Model, Backbone) {
           };
         };
         var url = collection.url()
-        expect(url).toMatch('//testdomain/performance/bucketname/api?');
+        expect(url).toMatch('//testdomain/performance/service/api/apiname?');
         expect(url).toMatch('filter_by=foo%3Abar');
         expect(url).toMatch('filter_by=b%3Ac');
         expect(url).toMatch('a=1');
@@ -366,14 +368,15 @@ function (Collection, Model, Backbone) {
     describe("sync", function () {
       it("escapes HTML characters in received response", function () {
         $.mockjax({
-          url: '//testdomain/performance/bucketname/api?',
+          url: '//testdomain/performance/service/api/apiname?',
           contentType: 'application/json',
           responseText: '[{"someProperty": "<b>html content</b>"}]'
         });
 
         var TestCollection = Collection.extend({
           baseUrl: '//testdomain/',
-          queryUrl: 'bucketname'
+          serviceName: 'service',
+          apiName: 'apiname'
         });
         var collection = new TestCollection();
 

--- a/spec/unit/backdrop_api_spec.rb
+++ b/spec/unit/backdrop_api_spec.rb
@@ -13,7 +13,7 @@ describe BackdropAPI do
       response = { "data" => "some-licenses" }
 
       FakeWeb.register_uri(:get,
-                           "http://backdrop/performance/licensing/api?group_by=licenceUrlSlug&collect=licenceName&sort_by=licenceName:ascending",
+                           "http://backdrop/performance/licensing/api/application?group_by=licenceUrlSlug&collect=licenceName&sort_by=licenceName:ascending",
                            :body => response.to_json)
             
       client = BackdropAPI.new("http://backdrop/")
@@ -31,7 +31,7 @@ describe BackdropAPI do
 
       FakeWeb.register_uri(
         :get,
-        "http://backdrop/performance/licensing/api?group_by=authorityUrlSlug&collect=authorityName&sort_by=authorityName:ascending",
+        "http://backdrop/performance/licensing/api/application?group_by=authorityUrlSlug&collect=authorityName&sort_by=authorityName:ascending",
         :body => response.to_json
       )
 
@@ -50,7 +50,7 @@ describe BackdropAPI do
       response = { "data" => "data-for-a-specific-licence" }
 
       FakeWeb.register_uri(:get,
-                           "http://backdrop/performance/licensing/api?filter_by=licenceUrlSlug:application-to-licence-a-street-collection&group_by=licenceUrlSlug&collect=licenceName",
+                           "http://backdrop/performance/licensing/api/application?filter_by=licenceUrlSlug:application-to-licence-a-street-collection&group_by=licenceUrlSlug&collect=licenceName",
                            :body => response.to_json)
 
       client = BackdropAPI.new("http://backdrop/")
@@ -69,7 +69,7 @@ describe BackdropAPI do
 
       FakeWeb.register_uri(
         :get,
-        "http://backdrop/performance/licensing/api?filter_by=authorityUrlSlug:some-auth-slug&group_by=authorityUrlSlug&collect=authorityName",
+        "http://backdrop/performance/licensing/api/application?filter_by=authorityUrlSlug:some-auth-slug&group_by=authorityUrlSlug&collect=authorityName",
         :body => response.to_json
       )
 
@@ -85,10 +85,10 @@ describe BackdropAPI do
       response = { "data" => "some-licence-data" }
 
       FakeWeb.register_uri(:get,
-                           "http://backdrop/performance/licensing/api?group_by=licenceUrlSlug&collect=licenceName&sort_by=licenceName:ascending", status: 401)
+                           "http://backdrop/performance/licensing/api/application?group_by=licenceUrlSlug&collect=licenceName&sort_by=licenceName:ascending", status: 401)
 
       FakeWeb.register_uri(:get,
-                           "http://doctor:who@backdrop/performance/licensing/api?group_by=licenceUrlSlug&collect=licenceName&sort_by=licenceName:ascending", :body => response.to_json)
+                           "http://doctor:who@backdrop/performance/licensing/api/application?group_by=licenceUrlSlug&collect=licenceName&sort_by=licenceName:ascending", :body => response.to_json)
 
       client = BackdropAPI.new("http://backdrop/", {username: 'doctor', password: 'who'})
       licences = client.get_licences


### PR DESCRIPTION
Previously we had one bucket for licensing. Journey data has gone into
another bucket. This change rearranges the URLs slightly so that the two
buckets are distinct but under the same service name.

The new URLs for this are.
/performance/licensing/api/application
- bucket licensing
- previously at /performance/licensing/api
  /performance/licensing/api/journey
- bucket licensing_journey

See also https://github.gds/gds/puppet/pull/589
