### PR TITLE
Remove completion rate module from fco dashboard

### DIFF
--- a/app/assets/javascripts/fco/controllers/overview.js
+++ b/app/assets/javascripts/fco/controllers/overview.js
@@ -39,13 +39,6 @@ define([
       });
     }
 
-    var successRate = new SuccessRateView({
-      el:$('#applications-success-rate'),
-      collection:conversionCollection.collectionInstances[1],
-      startStep:serviceName + ':start',
-      endStep:serviceName + ':done'
-    });
-
     conversionCollection.fetch();
 
     if ($('#number-of-visitors-realtime').length) {

--- a/app/views/fco/index.html.erb
+++ b/app/views/fco/index.html.erb
@@ -42,21 +42,7 @@
   <figure class="graph timeseries-graph" id="volumetrics-completion"></figure>
 </section>
 
-<section class="half-width row-start">
-<h1>Digital completion rate</h1>
-<ul class="module-actions">
-  <li class="info">
-    <div>
-      <p>Data sources: Google Analytics (unique visitors numbers based on sampled data)</p>
-      <p>Completion calculated as percentage of unique visitors who arrived at the done page out of those who arrived at the start page.</p>
-    </div>
-  </li>
-</ul>
-<h2>Completion rate for all digital submissions last week</h2>
-<p id="applications-success-rate" class="impact-number"></p>
-</section>
-
-<section class="graph half-width">
+<section>
   <h1>Submission drop-offs</h1>
   <ul class="module-actions">
     <li class="info">


### PR DESCRIPTION
Removing the completion rate single stat module from FCO dashboards, as this piece of information si already visible in the drop-off and volumetrics modules.
