### PR TITLE
Change conversion funnel to use Mon -> Sun weeks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ rvm:
 matrix:
   allow_failures:
     - rvm: 2.0.0
-env: CAPYBARA_WAIT_TIME=20
+env: CAPYBARA_WAIT_TIME=30

--- a/app/assets/javascripts/extensions/collections/conversioncollection.js
+++ b/app/assets/javascripts/extensions/collections/conversioncollection.js
@@ -5,7 +5,11 @@ define([
 
     queryParams: function() {
       var weeksAgo = this.options.weeksAgo || 0;
-      var startOfWeek = this.moment().day(1).startOf('day').subtract(weeksAgo, 'weeks');
+      var today = this.moment();
+      if (today.day() === 0) {
+        weeksAgo += 1;
+      }
+      var startOfWeek = today.day(1).startOf('day').subtract(weeksAgo, 'weeks');
       
       return {
         start_at: startOfWeek.clone().subtract(1, 'weeks'),

--- a/spec/javascripts/spec/extensions/collections/spec.conversioncollection.js
+++ b/spec/javascripts/spec/extensions/collections/spec.conversioncollection.js
@@ -37,6 +37,74 @@ define([
         expect(params.start_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-02-25T00:00:00');
         expect(params.end_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-03-04T00:00:00');
       });
+
+      describe("Monday to Sunday week boundaries", function () {
+        describe("Sundays", function () {
+          it("should start the query 13 days before and finish 6 days before - by default", function () {
+            var conversionCollection = new TestCollection();
+            setupMoment('2013-07-14', conversionCollection);
+
+            var params = conversionCollection.queryParams();
+            expect(params.start_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-01T00:00:00');
+            expect(params.end_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-08T00:00:00');
+          });
+
+          it("should start the query 20 days before and finish 13 days before - for 1 week ago", function () {
+            var conversionCollection = new TestCollection(null, {
+              weeksAgo: 1
+            });
+            setupMoment('2013-07-14', conversionCollection);
+
+            var params = conversionCollection.queryParams();
+            expect(params.start_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-06-24T00:00:00');
+            expect(params.end_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-01T00:00:00');
+          });
+        });
+
+        describe("Mondays", function () {
+          it("should start the query 7 days before and finish 0 days before - by default", function () {
+            var conversionCollection = new TestCollection();
+            setupMoment('2013-07-15', conversionCollection);
+
+            var params = conversionCollection.queryParams();
+            expect(params.start_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-08T00:00:00');
+            expect(params.end_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-15T00:00:00');
+          });
+
+          it("should start the query 13 days before and finish 7 days before - for 1 week ago", function () {
+            var conversionCollection = new TestCollection(null, {
+              weeksAgo: 1
+            });
+            setupMoment('2013-07-15', conversionCollection);
+
+            var params = conversionCollection.queryParams();
+            expect(params.start_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-01T00:00:00');
+            expect(params.end_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-08T00:00:00');
+          });
+        });
+
+        describe("Saturdays", function () {
+          it("should start the query 12 days before and finish 5 days before - by default", function () {
+            var conversionCollection = new TestCollection();
+            setupMoment('2013-07-13', conversionCollection);
+
+            var params = conversionCollection.queryParams();
+            expect(params.start_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-01T00:00:00');
+            expect(params.end_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-08T00:00:00');
+          });
+
+          it("should start the query 12 days before and finish 5 days before - for 1 week ago", function () {
+            var conversionCollection = new TestCollection(null, {
+              weeksAgo: 1
+            });
+            setupMoment('2013-07-13', conversionCollection);
+
+            var params = conversionCollection.queryParams();
+            expect(params.start_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-06-24T00:00:00');
+            expect(params.end_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-01T00:00:00');
+          });
+        });
+      });
     });
     
     describe("Sorting", function() {

--- a/spec/javascripts/spec/extensions/collections/spec.conversioncollection.js
+++ b/spec/javascripts/spec/extensions/collections/spec.conversioncollection.js
@@ -71,7 +71,7 @@ define([
             expect(params.end_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-15T00:00:00');
           });
 
-          it("should start the query 13 days before and finish 7 days before - for 1 week ago", function () {
+          it("should start the query 14 days before and finish 7 days before - for 1 week ago", function () {
             var conversionCollection = new TestCollection(null, {
               weeksAgo: 1
             });
@@ -93,7 +93,7 @@ define([
             expect(params.end_at.format('YYYY-MM-DDTHH:mm:ss')).toEqual('2013-07-08T00:00:00');
           });
 
-          it("should start the query 12 days before and finish 5 days before - for 1 week ago", function () {
+          it("should start the query 19 days before and finish 12 days before - for 1 week ago", function () {
             var conversionCollection = new TestCollection(null, {
               weeksAgo: 1
             });


### PR DESCRIPTION
`moment.js` starts weeks on a Sunday wheres the Performance Platform starts weeks on a Monday, consequently we were querying for the next weeks worth of data a day early, causing the conversion funnel to display 0% on a Sunday.

@moonpxi
@gtrogers
