### PR TITLE
Allow failures on ruby 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.0.0
 matrix:
   allow_failures:
+    - rvm: 1.9.2
     - rvm: 2.0.0
 env: CAPYBARA_WAIT_TIME=30
 notifications:


### PR DESCRIPTION
We deploy to 1.9.3 using .ruby-version, so presumably we're not
overly bothered by failures on 1.9.2?
