### PR TITLE
Repoint Transactions Explorer in header

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
   </a>
   <ul id="proposition-links">
     <li><a href="/performance/dashboard" class="">GOV.UK performance</a></li>
-    <li><a href="http://transactionsexplorer.cabinetoffice.gov.uk/" class="">Transactions Explorer</a></li>
+    <li><a href="/performance/transactions-explorer" class="">Transactions Explorer</a></li>
     <li><%= main_navigation_link_to "Services", services_path %></li>
   </ul>
 </nav>


### PR DESCRIPTION
Now that it's on preview, we might as well be able to click on it?
