### PR TITLE
Graph labels and general naming fixes

### DIFF
--- a/app/assets/javascripts/vehicle-licensing/collections/services.js
+++ b/app/assets/javascripts/vehicle-licensing/collections/services.js
@@ -10,7 +10,7 @@ function (GraphCollection) {
 
     baseSeriesList: [
       { id: 'successful_sorn', title: 'SORN' },
-      { id: 'successful_tax_disc', title: 'Tax-disc' }
+      { id: 'successful_tax_disc', title: 'Tax disc' }
     ],
 
     initialize: function (model, options) {

--- a/app/assets/javascripts/vehicle-licensing/controllers/vehicle-license-volumes-module.js
+++ b/app/assets/javascripts/vehicle-licensing/controllers/vehicle-license-volumes-module.js
@@ -31,7 +31,7 @@ define([
       var headline = new Headline({
         el: $(selector + '-headline'),
         model: serviceCollection.query,
-        prefix: 'Applications submissions'
+        prefix: 'Applications'
       });
       headline.render();
     };

--- a/app/assets/javascripts/vehicle-licensing/controllers/vehicle-license-volumes-module.js
+++ b/app/assets/javascripts/vehicle-licensing/controllers/vehicle-license-volumes-module.js
@@ -6,8 +6,13 @@ define([
 ],
   function (ServicesCollection, TimeseriesGraph, Tabs, Headline) {
     return function (selector, id, type) {
+      var serviceName = {
+        'sorn': 'SORN',
+        'tax-disc': 'Tax disc'
+      };
+
       var serviceCollection = new ServicesCollection([], {
-        seriesList: [{ id: id, title: type }]
+        seriesList: [{ id: id, title: serviceName[type] }]
       });
       serviceCollection.query.set('period', 'week');
       serviceCollection.fetch();

--- a/config/services.yml
+++ b/config/services.yml
@@ -33,5 +33,5 @@ dashboards:
     name: SORN
     feature-toggle: evl_dashboard
   - slug: tax-disc
-    name: Tax Disc
+    name: Tax disc
     feature_toggle: evl_dashboard


### PR DESCRIPTION
The story explains better than I do: https://www.pivotaltracker.com/story/show/55393972. Text below:

On the Tax Disc and SORN volumetric graphs
- remove 'submissions' from "Applications submissions per week over the last 9 weeks
- on hover label it should say SORN not sorn
- on hover label is should say Tax disc not tax-disc
- in services list it should be Tax disc not Tax Disc
