### PR TITLE
Fix table presentation in IE6-8

### DIFF
--- a/app/assets/javascripts/extensions/views/table/table.js
+++ b/app/assets/javascripts/extensions/views/table/table.js
@@ -229,20 +229,25 @@ function (View) {
       var tr = $('<tr></tr>');
 
       var tdString = options.header ? '<th></th>' : '<td></td>';
-
-      var that = this;
+      var iMax = options.columns.length - 1;
       _.each(options.columns, function (column, i) {
         var td = $(tdString);
         td.addClass(column.className || column.id);
+        if (i === 0) {
+          td.addClass('first-child');
+        }
+        if (i === iMax) {
+          td.addClass('last-child');
+        }
 
         var value;
         if (options.allowGetValue && typeof column.getValue === 'function') {
-          value = column.getValue.call(that, model, column); 
+          value = column.getValue.call(this, model, column); 
         } else {
           if (_.isFunction(model.get)) {
             value = model.get(column.id);
           } else if (_.isFunction(model[column.id])) {
-            value = model[column.id].call(that);
+            value = model[column.id].call(this);
           } else {
             value = model[column.id];
           }
@@ -253,10 +258,10 @@ function (View) {
         if (options.header && column.sortable) {
           td.addClass('sortable');
 
-          var currentSortColumn = (column.id === that.collection.sortAttr);
+          var currentSortColumn = (column.id === this.collection.sortAttr);
 
           if (currentSortColumn) {
-            td.addClass(that.collection.sortDescending ? 'descending' : 'ascending');
+            td.addClass(this.collection.sortDescending ? 'descending' : 'ascending');
           }
         }
       }, this);

--- a/app/assets/stylesheets/table.scss
+++ b/app/assets/stylesheets/table.scss
@@ -40,12 +40,24 @@ article table {
     }
     
     tbody {
+      td.first-child {
+          border-left:0;
+      }
+
       td:first-child {
           border-left:0;
       }
 
+      tr.first-child td {
+          border-top:0;
+      }
+
       tr:first-child td {
           border-top:0;
+      }
+
+      tr.last-child td {
+          border-bottom:0;
       }
 
       tr:last-child td {
@@ -74,6 +86,10 @@ article table {
         &.numeric {
             text-align: right;
         }
+        &.last-child {
+            border-right:0;
+            padding-right: 1em;
+        }
         &:last-child {
             border-right:0;
             padding-right: 1em;
@@ -86,6 +102,10 @@ article table {
         white-space:nowrap;
         word-wrap:break-word;
         
+        &.first-child {
+            border-left:0;
+        }
+
         &:first-child {
             border-left:0;
         }

--- a/spec/javascripts/spec/extensions/views/table/spec.table.js
+++ b/spec/javascripts/spec/extensions/views/table/spec.table.js
@@ -507,6 +507,22 @@ function (Table, Collection, Model) {
         expect(cells.eq(1).html()).toEqual('bar title');
         expect(cells.eq(1).hasClass('barclass')).toBe(true);
       });
+
+      it("adds fallback classes to the first and last element in a body row", function() {
+        var tr = table.renderRow(model);
+        var cells = tr.find('td');
+        expect(cells.eq(0)).toHaveClass('first-child');
+        expect(cells.eq(1)).toHaveClass('last-child');
+      });
+
+      it("adds fallback classes to the first and last element in a header row", function() {
+        var tr = table.renderRow(model, {
+          header: true
+        });
+        var cells = tr.find('th');
+        expect(cells.eq(0)).toHaveClass('first-child');
+        expect(cells.eq(1)).toHaveClass('last-child');
+      });
     });
 
     describe("applyPreventDocumentScroll", function () {


### PR DESCRIPTION
IE6-8 do not support :first-child and :last-child pseudo selectors.
Add fallback classes to first and last table columns and style those
correctly. Fallback styles need to be fully separated from pseudo class
rules as IE ignores the fallback style otherwise.
