### PR TITLE
Fix customer satisfaction module on IE 7

### DIFF
--- a/app/assets/javascripts/vehicle-licensing/controllers/customer-satisfaction-module.js
+++ b/app/assets/javascripts/vehicle-licensing/controllers/customer-satisfaction-module.js
@@ -5,12 +5,13 @@ define([
   function (Collection, View) {
     return function (selector, service) {
       var collection = new Collection();
-      collection.fetch();
 
       var view = new View({
         el: $(selector),
         collection: collection,
         service: service
       });
+
+      collection.fetch();
     };
   });


### PR DESCRIPTION
Customer satisfaction collection now fetched after initialising the view.

This should fix the rendering of the customer satisfaction module on
IE7. It seems to be caused by some weird race condition, only on IE; more
investigation needed on this.
