### PR TITLE
Fix colour swap for stack component

### DIFF
--- a/app/assets/javascripts/extensions/views/graph/stack.js
+++ b/app/assets/javascripts/extensions/views/graph/stack.js
@@ -75,9 +75,19 @@ function (require, Line, Component) {
           .attr("class", function (group, index) {
             return 'line line' + (maxGroupIndex-index) + ' ' + group.get('id');
           });
+
       selectionLines.select('path').attr("d", function(group, groupIndex) {
         return line(group.get('values').models);
       });
+
+      // Restore correct order element order. Order gets mixed up on selection
+      // change when we bring the 'selected' line to front.
+      this.collection.each(function (group, groupIndex) {
+        var index = maxGroupIndex - groupIndex;
+        var line = selectionLines.select('path.line' + index);
+        var group = line.node().parentNode;
+        group.parentNode.appendChild(group);
+      }, this);
     },
 
     onChangeSelected: function (groupSelected, groupIndexSelected, modelSelected, indexSelected) {

--- a/spec/javascripts/spec/extensions/views/graph/spec.stack.js
+++ b/spec/javascripts/spec/extensions/views/graph/spec.stack.js
@@ -43,10 +43,10 @@ function (Stack, Collection) {
     });
     
     describe("render", function() {
-      
-      it("renders a stack consisting of a stroked path and a filled path for each item in the collection", function() {
-        
-        var view = new Stack({
+
+      var view;
+      beforeEach(function() {
+        view = new Stack({
           interactive: false,
           wrapper: wrapper,
           collection: collection,
@@ -68,14 +68,33 @@ function (Stack, Collection) {
             return model.y0;
           }
         });
+      });
+      
+      it("renders a stack consisting of a stroked path and a filled path for each item in the collection", function() {
         view.render();
-        
         var group1 = wrapper.selectAll('g.group:nth-child(1)');
         expect(group1.selectAll('path.line').attr('d')).toEqual('M1,6L5,14L9,22');
         expect(group1.selectAll('path.stack').attr('d')).toEqual('M1,6L5,14L9,22L9,0L5,0L1,0Z');
         var group2 = wrapper.selectAll('g.group:nth-child(2)');
         expect(group2.selectAll('path.line').attr('d')).toEqual('M1,10L5,26L9,42');
         expect(group2.selectAll('path.stack').attr('d')).toEqual('M1,10L5,26L9,42L9,22L5,14L1,6Z');
+      });
+
+      it("ensures that elements are rendered in correct order after an element was selected", function () {
+        // correct rendering order for stack is from bottom to top
+        view.render();
+        expect(wrapper.select('g.group:nth-child(1) path.line').attr('class')).toContain('line1');
+        expect(wrapper.select('g.group:nth-child(2) path.line').attr('class')).toContain('line0');
+
+        // selecting a group brings the line to front
+        view.onChangeSelected(collection.at(1), 1, null, null);
+        expect(wrapper.select('g.group:nth-child(1) path.line').attr('class')).toContain('line0');
+        expect(wrapper.select('g.group:nth-child(2) path.line').attr('class')).toContain('line1');
+
+        // on re-render, the correct order should be restored
+        view.render();
+        expect(wrapper.select('g.group:nth-child(1) path.line').attr('class')).toContain('line1');
+        expect(wrapper.select('g.group:nth-child(2) path.line').attr('class')).toContain('line0');
       });
 
     });


### PR DESCRIPTION
Selecting a group changes display order of SVG elements.
We now ensure that the element order is correct on re-render.
