### PR TITLE
Update backdrop default url

### DIFF
--- a/config/initializers/backdrop.rb
+++ b/config/initializers/backdrop.rb
@@ -1,5 +1,2 @@
-backdrop_location = 'http://publicapi.dev.gov.uk'
-if Rails.env.test?
-  backdrop_location = '/backdrop_stub'
-end
+backdrop_location = Rails.env.test? ? '/backdrop_stub' : '/'
 Limelight::Application.config.backdrop_url = ENV["BACKDROP_URL"] || backdrop_location


### PR DESCRIPTION
Domain removed from backend base URL. By default limelight now expects the backend API to be served from the same domain.
