### PR TITLE
Revert commit that undid accidental push to master

### DIFF
--- a/app/views/tax-disc/index.html.erb
+++ b/app/views/tax-disc/index.html.erb
@@ -1,6 +1,6 @@
 <%
   transaction_title = 'Tax disc'
-  explanatory_copy = 'Service provided by the DVLA to license motor vehicles that are kept on public roads.'
+  explanatory_copy = 'Service provided by the DVLA to relicense motor vehicles that are kept on public roads. This service does not include first vehicle registrations.'
   transaction_shortname = 'Tax disc'
   @js_config = {
     "controller" => "vehicle-licensing/controllers/vehicle-licensing-service",
@@ -47,7 +47,7 @@
   title: "Applications", 
   description: "", 
   id: "#{params[:slug]}-volumes", 
-  info_text: "Shows the number of successful applications to buy or renew a tax disc received by the DVLA.",
+  info_text: "Shows the number of successful applications to renew a tax disc received by the DVLA.",
   transaction_title:transaction_title,
   transaction_shortname:transaction_shortname
 }) %>

--- a/app/views/vehicle-licensing/_failures.html.erb
+++ b/app/views/vehicle-licensing/_failures.html.erb
@@ -6,7 +6,8 @@
     <li class="info">
       <div>
         <p>Data source: <abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr> database</p>
-        <p>Shows errors that have been logged in the web transaction. More than one error may be logged per user.</p>
+        <p>Shows errors that have been logged in the web transaction.</p>
+        <p>More than one error may be logged per user.</p>
       </div>
     </li>
   </ul>

--- a/app/views/vehicle-licensing/index.html.erb
+++ b/app/views/vehicle-licensing/index.html.erb
@@ -11,7 +11,7 @@
     <span class="strapline">Service group performance</span>
       Vehicle licensing
   </h1>
-  <p class="explanatory">A group of services provided by the <abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr> relating to vehicle licensing: Tax disc relicensing, and SORN (Statutory Off Road Notification).</p>
+  <p class="explanatory">A group of services provided by the <abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr> relating to vehicle licensing: Tax disc relicensing, and SORN (Statutory Off Road Notification). Does not include first registrations.</p>
 </header>
 
 <section class="graph">
@@ -20,7 +20,7 @@
     <li class="info">
       <div>
         <p>Data source: <abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr> database</p>
-        <p>Shows the weekly number of successful applications to buy or renew a tax disc and the number of <abbr title="Statutory Off Road Notification">SORN</abbr>'s received.</p>
+        <p>Shows the weekly number of successful applications to renew a tax disc and the number of <abbr title="Statutory Off Road Notification">SORN</abbr>'s received.</p>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
This reverts commit 3a70057bf2192658a669a803021ceeadb8b1c36a.

Change tax disc copy to make explicit it only includes relicensing, not first registrations.
