### PR TITLE
Move services link in main nav

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,9 @@
     <span class="alpha-tag">Alpha</span>
   </a>
   <ul id="proposition-links">
-    <li><a href="/performance/dashboard" class="">GOV.UK performance</a></li>
-    <li><a href="/performance/transactions-explorer" class="">Transactions Explorer</a></li>
     <li><%= main_navigation_link_to "Services", services_path %></li>
+    <li><a href="/performance/dashboard" class="">GOV.UK performance</a></li>
+    <li><a href="/performance/transactions-explorer" class="">Transactions Explorer</a></li>   
   </ul>
 </nav>
 


### PR DESCRIPTION
Move services link in main nav to far left.

This should be deployed at the same time as companion pull requests on Datainsight-frontend and Transactions Explorer
