### PR TITLE
Adjust width of impact number.

### DIFF
--- a/app/assets/stylesheets/volumetrics-availability.scss
+++ b/app/assets/stylesheets/volumetrics-availability.scss
@@ -3,7 +3,7 @@
 .volumetrics, .availability {
   .impact-number {
     padding-top:1em;
-    width: 12.5em;
+    width: 12.3em;
     float:left;
     @include core-16($tabular-numbers: true);
     color: $black;


### PR DESCRIPTION
Too large width will push the graph down, as it won't be able to fit on
the screen.
