### PR TITLE
Don't use tabular fonts for copy text

### DIFF
--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -3,11 +3,11 @@
 @import 'colours';
 
 h2 {
-  @include core-19($tabular-numbers: true) ;
+  @include core-19;
 }
 
 p {
-  @include core-16($tabular-numbers: true) ;
+  @include core-16;
 }
 
 a[rel="external"] {
@@ -24,29 +24,29 @@ a[rel="external"] {
   
   header {
     h1 {
-      @include bold-48($tabular-numbers: true) ;
+      @include bold-48;
 
       span.tagline {
         display:block;
-        @include core-16($tabular-numbers: true) ;
+        @include core-16;
         color: $grey-1;
       }
 
       span.strapline {
         display: block;
-        @include core-27($tabular-numbers: true) ;
+        @include core-27;
         color: $grey-1;
         margin-bottom: 5px;
       }
     }
     h2 {
-      @include core-16($tabular-numbers: true) ;
+      @include core-16;
       margin:0;
       color: $grey-1;
     }
 
     p.category-title {
-      @include core-24($tabular-numbers: true) ;
+      @include core-24;
       color: $grey-1;
       margin-bottom:.5em;
 
@@ -61,7 +61,7 @@ a[rel="external"] {
     }
 
     p.explanatory {
-      @include core-16($tabular-numbers: true) ;
+      @include core-16;
       color: $black;
       margin-bottom: -1em;
       padding: 0.6em 0 0 0;
@@ -73,12 +73,12 @@ a[rel="external"] {
     margin-bottom:1.5em;
 
     h1 {
-      @include bold-24($tabular-numbers: true) ;
+      @include bold-24;
     }
 
     h2 {
       margin-top:0;
-      @include core-16($tabular-numbers: true) ;
+      @include core-16;
     }
   }
 }


### PR DESCRIPTION
I've removed the tabular font usage from section headers, explanatory
text and general info text. We are still using it for tables, graphs and
all performance/metric related information.
