### PR TITLE
Move H2's next to H1's for consistency

### DIFF
--- a/app/views/lasting-power-of-attorney/index.html.erb
+++ b/app/views/lasting-power-of-attorney/index.html.erb
@@ -16,6 +16,7 @@
 <% if Rails.application.config.feature_toggles[:lpa_dashboard_application_method] %>
 <section class="graph graph-with-labels application-method-over-time">
   <h1>Applications</h1>
+  <h2><span class="group0">Non-digital</span> and <span class="group1">digital</span> applications over time</h2>
   <ul class="module-actions">
     <li class="info">
       <div>
@@ -26,7 +27,6 @@
       </div>
     </li>
   </ul>
-  <h2><span class="group0">Non-digital</span> and <span class="group1">digital</span> applications over time</h2>
   <figure class="graph" id="application-method-over-time"></figure>
 </section>
 <% end %>

--- a/app/views/sorn/index.html.erb
+++ b/app/views/sorn/index.html.erb
@@ -27,6 +27,7 @@
 
 <section id="customer-satisfaction" class="half-width">
   <h1>Customer satisfaction</h1>
+  <h2>Average score of satisfied responses</h2>
   <ul class="module-actions">
     <li class="info">
       <div>
@@ -35,7 +36,6 @@
       </div>
     </li>
   </ul>
-  <h2>Average score of satisfied responses</h2>
   <p class="impact-number current-value"></p>
   <p class="stat-description current-date"></p>
   <div class="previous-month">

--- a/app/views/tax-disc/index.html.erb
+++ b/app/views/tax-disc/index.html.erb
@@ -25,6 +25,7 @@
 
 <section id="customer-satisfaction" class="half-width">
   <h1>Customer satisfaction (web)</h1>
+  <h2>Average satisfaction score last month</h2>
   <ul class="module-actions">
     <li class="info">
       <div>
@@ -34,7 +35,6 @@
       </div>
     </li>
   </ul>
-  <h2>Average satisfaction score last month</h2>
   <p class="impact-number current-value"></p>
   <p class="stat-description current-date"></p>
   <div class="previous-month">

--- a/app/views/vehicle-licensing/_volumetrics.html.erb
+++ b/app/views/vehicle-licensing/_volumetrics.html.erb
@@ -4,6 +4,7 @@
 <% info_text ||= "The number of successful applications for a #{transaction_shortname}." %>
 <section class="graph graph-with-labels vehicle-licensing-volumetrics">
   <h1><%= title %></h1>
+  <h2 id="<%= id %>-headline"><%= description %></h2>
   <ul class="module-actions">
     <li class="info">
       <div>
@@ -13,7 +14,6 @@
     </li>
   </ul>
   <nav id="<%= id %>-nav"></nav>
-  <h2 id="<%= id %>-headline"><%= description %></h2>
   <figure class="graph timeseries-graph" id="<%= id %>"></figure>
 </section>
 

--- a/app/views/vehicle-licensing/index.html.erb
+++ b/app/views/vehicle-licensing/index.html.erb
@@ -16,6 +16,7 @@
 
 <section class="graph graph-with-labels">
   <h1>Applications by service</h1>
+  <h2>Vehicle licensing applications per month broken down by service</h2>
   <ul class="module-actions">
     <li class="info">
       <div>
@@ -24,7 +25,6 @@
       </div>
     </li>
   </ul>
-  <h2>Vehicle licensing applications per month broken down by service</h2>
   <figure class="graph timeseries-graph" id="vehicle-licensing-services"></figure>
 </section>
 


### PR DESCRIPTION
Some H2's were after the info text, some weren't. This caused some visual inconsistency in the spacing on the modules.
