### PR TITLE
Swap stacked order

### DIFF
--- a/app/assets/javascripts/vehicle-licensing/collections/services.js
+++ b/app/assets/javascripts/vehicle-licensing/collections/services.js
@@ -18,14 +18,14 @@ function (GraphCollection) {
 
     seriesList: [
       {
-        id: 'sorn',
-        title: 'SORN',
-        href: '/performance/sorn'
-      },
-      {
         id: 'tax-disc',
         title: 'Tax disc',
         href: '/performance/tax-disc'
+      },
+      {
+        id: 'sorn',
+        title: 'SORN',
+        href: '/performance/sorn'
       }
     ],
 

--- a/app/assets/javascripts/vehicle-licensing/collections/volumetrics.js
+++ b/app/assets/javascripts/vehicle-licensing/collections/volumetrics.js
@@ -17,9 +17,9 @@ function (GraphCollection) {
     },
 
     seriesList: [
-      { id: 'manual', title: 'Manual' },
+      { id: 'fully-digital', title: 'Digital' },
       { id: 'assisted-digital', title: 'Post Office' },
-      { id: 'fully-digital', title: 'Digital' }
+      { id: 'manual', title: 'Manual' }
     ],
 
     parse: function (response) {

--- a/spec/javascripts/spec/vehicle-licensing/collections/spec.services.js
+++ b/spec/javascripts/spec/vehicle-licensing/collections/spec.services.js
@@ -41,22 +41,6 @@ function (ServicesCollection) {
 
     var expected = [
       {
-        "id": "sorn",
-        "title": "SORN",
-        "href": "/performance/sorn",
-        "values": [
-          {
-            "_end_at": "2012-09-01T00:00:00+00:00", 
-            "_start_at": "2012-08-01T00:00:00+00:00"
-          }, 
-          {
-            "_end_at": "2012-10-01T00:00:00+00:00", 
-            "volume:sum": 4,
-            "_start_at": "2012-09-01T00:00:00+00:00"
-          }
-        ]
-      },
-      {
         "id": "tax-disc",
         "title": "Tax disc",
         "href": "/performance/tax-disc",
@@ -69,6 +53,22 @@ function (ServicesCollection) {
           {
             "_end_at": "2012-10-01T00:00:00+00:00", 
             "volume:sum": 2,
+            "_start_at": "2012-09-01T00:00:00+00:00"
+          }
+        ]
+      },
+      {
+        "id": "sorn",
+        "title": "SORN",
+        "href": "/performance/sorn",
+        "values": [
+          {
+            "_end_at": "2012-09-01T00:00:00+00:00", 
+            "_start_at": "2012-08-01T00:00:00+00:00"
+          }, 
+          {
+            "_end_at": "2012-10-01T00:00:00+00:00", 
+            "volume:sum": 4,
             "_start_at": "2012-09-01T00:00:00+00:00"
           }
         ]

--- a/spec/javascripts/spec/vehicle-licensing/collections/spec.volumetrics.js
+++ b/spec/javascripts/spec/vehicle-licensing/collections/spec.volumetrics.js
@@ -57,8 +57,8 @@ function (VolumetricsCollection) {
 
     var expected = [
       {
-        "id": "manual",
-        "title": "Manual",
+        "id": "fully-digital",
+        "title": "Digital",
         "values": [
           {
             "_end_at": "2012-09-01T00:00:00+00:00", 
@@ -67,6 +67,7 @@ function (VolumetricsCollection) {
           }, 
           {
             "_end_at": "2012-10-01T00:00:00+00:00", 
+            "volume:sum": 4,
             "_start_at": "2012-09-01T00:00:00+00:00"
           }
         ]
@@ -88,8 +89,8 @@ function (VolumetricsCollection) {
         ]
       }, 
       {
-        "id": "fully-digital",
-        "title": "Digital",
+        "id": "manual",
+        "title": "Manual",
         "values": [
           {
             "_end_at": "2012-09-01T00:00:00+00:00", 
@@ -98,7 +99,6 @@ function (VolumetricsCollection) {
           }, 
           {
             "_end_at": "2012-10-01T00:00:00+00:00", 
-            "volume:sum": 4,
             "_start_at": "2012-09-01T00:00:00+00:00"
           }
         ]


### PR DESCRIPTION
Swap orders of items in stacked graphs so that smaller volumes are on the bottom (making them more easy to read).

Note - before updating tests to match, running jasmine through rake test:all crashed, rather than failing.
