### PR TITLE
Style linelabel links as links

### DIFF
--- a/app/assets/javascripts/extensions/views/graph/linelabel.js
+++ b/app/assets/javascripts/extensions/views/graph/linelabel.js
@@ -147,6 +147,8 @@ function (require, Component) {
         selection.selectAll('a').attr('href', function (group, groupIndex) {
           return group.get('href');
         });
+        enterSelection.append('span');
+        selection.selectAll('span').attr('class', 'meta');
       }
 
       selection.each(function(group, i) {
@@ -220,7 +222,8 @@ function (require, Component) {
     },
 
     setLabelContent: function (selection, group, groupIndex) {
-      var labelHTML = "<span class='label-title'>" + group.get('title') + "</span>";
+      var labelTitle = "<span class='label-title'>" + group.get('title') + "</span>",
+          labelMeta = '';
 
       if (this.showValues) {
         var attr = this.graph.valueAttr,
@@ -234,23 +237,24 @@ function (require, Component) {
         }
 
         if (value === null) {
-          labelHTML += "<span class='no-data'>(no data)</span>";
+          labelMeta += "<span class='no-data'>(no data)</span>";
         } else {
-          labelHTML += ("<span class='value'>" + this.formatNumericLabel(value) + "</span>");
+          labelMeta += ("<span class='value'>" + this.formatNumericLabel(value) + "</span>");
         }
 
         if (this.showValuesPercentage && value) {
           var fraction = this.collection.fraction(
             attr, groupIndex, selected.selectedModelIndex
           );
-          labelHTML += (" <span class='percentage'>(" + this.formatPercentage(fraction) + ")</span>");
+          labelMeta += (" <span class='percentage'>(" + this.formatPercentage(fraction) + ")</span>");
         }
       }
 
       if (this.attachLinks) {
-        selection.select('a').html(labelHTML);
+        selection.select('a').html(labelTitle);
+        selection.select('.meta').html(labelMeta);
       } else {
-        selection.html(labelHTML);
+        selection.html(labelTitle + labelMeta);
       }
 
     },

--- a/app/assets/stylesheets/graph.scss
+++ b/app/assets/stylesheets/graph.scss
@@ -25,7 +25,6 @@
   }
 
   .graph-wrapper {
-
     position:relative;
 
     .inner {
@@ -253,11 +252,6 @@
 
         &.selected {
           font-weight: bold;
-        }
-
-        a {
-          color: $text-colour;
-          text-decoration: none;
         }
 
         .label-title {

--- a/spec/javascripts/spec/extensions/views/graph/spec.linelabel.js
+++ b/spec/javascripts/spec/extensions/views/graph/spec.linelabel.js
@@ -76,9 +76,12 @@ function (LineLabel, Collection) {
           expect(lineLabel.$el.find('figcaption ol')).toHaveClass('squares');
         });
 
-        it("does not render links by default", function () {
+        it("does not render links, values, percentages or timeperiods by default", function () {
           lineLabel.render();
           expect(lineLabel.$el.find('figcaption li a').length).toEqual(0);
+          expect(lineLabel.$el.find('figcaption li span.value').length).toEqual(0);
+          expect(lineLabel.$el.find('figcaption li span.percentage').length).toEqual(0);
+          expect(lineLabel.$el.find('figcaption .summary span.timeperiod').length).toEqual(0);
         });
 
         it("renders links when enabled", function () {
@@ -104,6 +107,19 @@ function (LineLabel, Collection) {
           expect(label2.find('span.value')).toHaveText('210');
         });
 
+        it("renders links and additional value text when selected", function () {
+          lineLabel.attachLinks = true;
+          lineLabel.showValues = true;
+          lineLabel.render();
+
+          var link1 = lineLabel.$el.find('figcaption ol li a').eq(0);
+          expect(link1.text()).toEqual('Title 1');
+          var link2 = lineLabel.$el.find('figcaption ol li a').eq(1);
+          expect(link2.text()).toEqual('Title 2');
+          var spanValues = lineLabel.$el.find('figcaption ol li span.value');
+          expect(spanValues.length).toEqual(2);
+        });
+
         it("renders a label with additional value text and percentage when enabled", function () {
           lineLabel.showValues = true;
           lineLabel.showValuesPercentage = true;
@@ -124,12 +140,6 @@ function (LineLabel, Collection) {
           expect(summary.find('span.title')).toHaveText('Total');
           expect(summary.find('span.value')).toHaveText('270');
           expect(summary.find('span.percentage')).toHaveText('(100%)');
-        });
-
-        it("does not render a time period label by default", function () {
-          lineLabel.render();
-          var summary = lineLabel.$el.find('figcaption .summary');
-          expect(summary.find('span.timeperiod').length).toEqual(0);
         });
 
         it("renders a time period label when enabled", function () {


### PR DESCRIPTION
Not as text.

Only the title of the service should be clickable, the rest should be text. Interaction should be as before, except with the click target reduced.
