### PR TITLE
Fix help usage

### DIFF
--- a/app/assets/javascripts/lpa/collections/help-usage.js
+++ b/app/assets/javascripts/lpa/collections/help-usage.js
@@ -9,7 +9,7 @@ define([
 
       queryParams: function () {
         return _.extend(this.lastWeekDateRangeParams(this.moment()), {
-          filter_by: 'eventAction:help',
+          filter_by: 'eventAction:help.inline',
           group_by: 'eventLabel',
           collect: [
             'uniqueEvents'

--- a/app/assets/javascripts/lpa/collections/help-usage.js
+++ b/app/assets/javascripts/lpa/collections/help-usage.js
@@ -10,7 +10,7 @@ define([
       queryParams: function () {
         return _.extend(this.lastWeekDateRangeParams(this.moment()), {
           filter_by: 'eventAction:help.inline',
-          group_by: 'eventLabel',
+          group_by: 'eventDestination',
           collect: [
             'uniqueEvents'
           ]
@@ -20,7 +20,7 @@ define([
       parse: function (response) {
         return _.map(response.data, function (d) {
           return {
-            description: d.eventLabel,
+            description: d.eventDestination,
             count: d.uniqueEvents[0]
           }
         });

--- a/app/controllers/backdrop_stub_controller.rb
+++ b/app/controllers/backdrop_stub_controller.rb
@@ -21,7 +21,7 @@ class BackdropStubController < ApplicationController
           StubConfig.new({'service' => 'pay-foreign-marriage-certificates', 'api_name' => 'monitoring', 'period' => 'day'}, 'foreign_marriage_availability_day.json'),
           StubConfig.new({'service' => 'pay-register-death-abroad', 'api_name' => 'journey'}, 'pay-register-death-abroad-journey.json'),
           StubConfig.new({'service' => 'deposit-foreign-marriage', 'api_name' => 'journey'}, 'journey-with-missing-data.json'),
-          StubConfig.new({'service' => 'lasting-power-of-attorney', 'api_name' => 'journey', 'group_by' => 'eventLabel', 'filter_by' => 'eventAction:help'}, 'lpa_help_usage.json'),
+          StubConfig.new({'service' => 'lasting-power-of-attorney', 'api_name' => 'journey', 'group_by' => 'eventDestination', 'filter_by' => 'eventAction:help.inline'}, 'lpa_help_usage.json'),
           StubConfig.new({'service' => 'lasting-power-of-attorney', 'api_name' => 'journey'}, 'lpa_journey.json'),
           StubConfig.new({'service' => 'lasting-power-of-attorney', 'api_name' => 'monitoring'}, 'lpa_availability.json'),
           StubConfig.new({'service' => 'lasting-power-of-attorney'}, 'lpa_volumes.json'),

--- a/features/backdrop_stub_responses/lpa_help_usage.json
+++ b/features/backdrop_stub_responses/lpa_help_usage.json
@@ -4,7 +4,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "about-this-tool",
+      "eventDestination": "about-this-tool",
       "uniqueEvents": [
         74.0
       ]
@@ -12,7 +12,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "applicant",
+      "eventDestination": "applicant",
       "uniqueEvents": [
         26.0
       ]
@@ -20,7 +20,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "attorneys",
+      "eventDestination": "attorneys",
       "uniqueEvents": [
         91.0
       ]
@@ -28,7 +28,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "certificate-providers",
+      "eventDestination": "certificate-providers",
       "uniqueEvents": [
         297.0
       ]
@@ -36,7 +36,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "correspondence-address",
+      "eventDestination": "correspondence-address",
       "uniqueEvents": [
         15.0
       ]
@@ -44,7 +44,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "donor",
+      "eventDestination": "donor",
       "uniqueEvents": [
         95.0
       ]
@@ -52,7 +52,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "fees-and-discounts",
+      "eventDestination": "fees-and-discounts",
       "uniqueEvents": [
         17.0
       ]
@@ -60,7 +60,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "fees-and-reductions",
+      "eventDestination": "fees-and-reductions",
       "uniqueEvents": [
         119.0
       ]
@@ -68,7 +68,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "how-attorneys-make-decisions",
+      "eventDestination": "how-attorneys-make-decisions",
       "uniqueEvents": [
         31.0
       ]
@@ -76,7 +76,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "life-sustaining-treatment",
+      "eventDestination": "life-sustaining-treatment",
       "uniqueEvents": [
         24.0
       ]
@@ -84,7 +84,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "lpa-basics",
+      "eventDestination": "lpa-basics",
       "uniqueEvents": [
         359.0
       ]
@@ -92,7 +92,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "paying-attorneys",
+      "eventDestination": "paying-attorneys",
       "uniqueEvents": [
         22.0
       ]
@@ -100,7 +100,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "people-to-be-told",
+      "eventDestination": "people-to-be-told",
       "uniqueEvents": [
         160.0
       ]
@@ -108,7 +108,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "previous-powers-of-attorney",
+      "eventDestination": "previous-powers-of-attorney",
       "uniqueEvents": [
         12.0
       ]
@@ -116,7 +116,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "registering-the-lpa",
+      "eventDestination": "registering-the-lpa",
       "uniqueEvents": [
         312.0
       ]
@@ -124,7 +124,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "replacement-attorneys",
+      "eventDestination": "replacement-attorneys",
       "uniqueEvents": [
         63.0
       ]
@@ -132,7 +132,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "restrictions-and-guidance",
+      "eventDestination": "restrictions-and-guidance",
       "uniqueEvents": [
         66.0
       ]
@@ -140,7 +140,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "signing-the-lpa",
+      "eventDestination": "signing-the-lpa",
       "uniqueEvents": [
         411.0
       ]
@@ -148,7 +148,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "the-2-types-of-lpa",
+      "eventDestination": "the-2-types-of-lpa",
       "uniqueEvents": [
         94.0
       ]
@@ -156,7 +156,7 @@
     {
       "_count": 1.0,
       "_group_count": 1,
-      "eventLabel": "when-an-lpa-can-be-used",
+      "eventDestination": "when-an-lpa-can-be-used",
       "uniqueEvents": [
         44.0
       ]

--- a/spec/javascripts/spec/lpa/collections/spec.help-usage.js
+++ b/spec/javascripts/spec/lpa/collections/spec.help-usage.js
@@ -13,7 +13,7 @@ define([
 
           var params = collection.queryParams();
 
-          expect(params.filter_by).toEqual('eventAction:help');
+          expect(params.filter_by).toEqual('eventAction:help.inline');
           expect(params.group_by).toEqual('eventLabel');
           expect(params.collect).toEqual(['uniqueEvents']);
           expect(params.start_at).toBeMoment(moment('2013-09-23 00:00:00'));

--- a/spec/javascripts/spec/lpa/collections/spec.help-usage.js
+++ b/spec/javascripts/spec/lpa/collections/spec.help-usage.js
@@ -14,7 +14,7 @@ define([
           var params = collection.queryParams();
 
           expect(params.filter_by).toEqual('eventAction:help.inline');
-          expect(params.group_by).toEqual('eventLabel');
+          expect(params.group_by).toEqual('eventDestination');
           expect(params.collect).toEqual(['uniqueEvents']);
           expect(params.start_at).toBeMoment(moment('2013-09-23 00:00:00'));
           expect(params.end_at).toBeMoment(moment('2013-09-30 00:00:00'));
@@ -26,15 +26,18 @@ define([
           var response = {
             "data": [
               {
-                "eventLabel":"help1",
+                "eventLabel":"page1:help1",
+                "eventDestination":"help1",
                 "uniqueEvents": [123]
               },
               {
-                "eventLabel":"help2",
+                "eventLabel":"page1:help2",
+                "eventDestination":"help2",
                 "uniqueEvents":[456]
               },
               {
-                "eventLabel":"help3",
+                "eventLabel":"page1:help3",
+                "eventDestination":"help3",
                 "uniqueEvents":[789]
               }
             ]


### PR DESCRIPTION
LPA enhanced their stageprompt tracking. They now add to the event label the source of event (which page the help was clicked, example `stageprompt.lpa:help.inline:create/lpa-type:what-if-i-want-to-make-more-than-one-lpa`).

This required a change in the backdrop ga collector to handle multiple values in a field: https://github.com/alphagov/backdrop-ga-collector/pull/14

Limelight had to change in a few places:
- They want `help.inline`, not `help` usage.
- Use `eventDestination`, instead of full `eventLabel`, for description.

**WARNING: Can only deploy after LPA release their changes and collectors are updated. Coordinate with Data-In.**
