### PR TITLE
Remove Ruby 1.9.2 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
 matrix:
   allow_failures:
-    - rvm: 1.9.2
     - rvm: 2.0.0
 env:
   global:


### PR DESCRIPTION
Capybara has a hard requirement on 1.9.3, so `bundle install` will never ever ever succeed on 1.9.2. Let's stop wasting Travis' resources.
