### PR TITLE
Temporarily revert section name

### DIFF
--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -48,7 +48,7 @@
     </section>
 
     <section class="cols2 service-listing">
-      <h2>Activity on GOV.UK</h2>
+      <h2>GOV.UK performance</h2>
       <p>Web traffic on our site, including a look at how our content is being used.</p>
       <ul>
         <li><a href="/performance/dashboard">GOV.UK Overview</a></li>


### PR DESCRIPTION
Reverting section name to work around issue with Transactions Explorer. Change will be made at later date.
