### PR TITLE
Make the global header bar use the brand colour

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -14,6 +14,9 @@
   padding-top:2em;
 }
 
+#global-header-bar .header-bar {
+  background: $primary-colour;
+}
 #global-breadcrumb {
   ol {
     border-top-color: $primary-colour;


### PR DESCRIPTION
The new global-header-bar is going to be introduced in static. It should
remain in the colour that is currently being used. The old border-colour 
on the breadcrumb can be removed after static has been deployed.
